### PR TITLE
Fixing mixed-mode warnings for favicons

### DIFF
--- a/app/BTAppNode.js
+++ b/app/BTAppNode.js
@@ -236,7 +236,7 @@ class BTAppNode extends BTNode {
             const favUrl =
                   n.faviconUrl ||
                   await localFileManager.get(host) ||
-                  `http://www.google.com/s2/favicons?domain=${host}`;
+                  `https://www.google.com/s2/favicons?domain=${host}`;
             n.faviconUrl = favUrl;
             const dn = n.getDisplayNode();
             const fav = n.favicon();


### PR DESCRIPTION
https instead of http. Not tested (N00b not knowing how to get the unpacked extension to get the code currently in "App")