### PR TITLE
Fix #38: links open inside the BT standalone window on Vivaldi

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -563,6 +563,15 @@ function updateBTIcon(text, title, color) {
         {'color' : color});
 }
 
+// helper for find correct windowId in vivaldi
+async function nonBTWindowId() {
+    if (BTManagerHome !== 'WINDOW') return null;
+    const all = await chrome.windows.getAll();
+    if (!all.some(w => 'vivExtData' in w)) return null;
+    const [, BTWin] = await getBTTabWin();
+    return all.find(w => w.id !== BTWin && w.type === 'normal')?.id || null;
+}
+
 function openTabs(msg, sender) {
     // open list of {nodeId, url} pairs, potentially in new window
 
@@ -588,14 +597,14 @@ function openTabs(msg, sender) {
             tabOpened(win.id, win.tabs[0].id, first.nodeId, win.tabs[0].index);
             openTabsInWin(rest, win.id);
         });
-    else if (!defaultWinId) openTabsInWin(msg.tabs);                      // open in current win
+    else if (!defaultWinId) nonBTWindowId().then(id => openTabsInWin(msg.tabs, id));
     else
         // else check window exists & iterate on all adding to current window
         chrome.windows.get(defaultWinId, (w) => {
             if (!w) {
                 // in rare error case win may no longer exist => set to null
                 console.warn(`Error in openTabs. ${chrome.runtime.lastError?.message}`);
-                openTabsInWin(msg.tabs);
+                nonBTWindowId().then(id => openTabsInWin(msg.tabs, id));
             } else {
                 openTabsInWin(msg.tabs, defaultWinId);
             }
@@ -647,9 +656,10 @@ function openTabGroups(msg, sender) {
                                       openTabsInTg(win.id, tgid, rest);
                                   });
             });
-        else 
+        else
             // create tg in current window
-            chrome.tabs.create({'url': first.url}, tab => {
+            nonBTWindowId().then(id => chrome.tabs.create(
+                id ? {'url': first.url, 'windowId': id} : {'url': first.url}, tab => {
                 check(); if (!tab) return;
                 chrome.tabs.group({'tabIds': tab.id,
                                    'createProperties': {'windowId': tab.windowId}},
@@ -660,7 +670,7 @@ function openTabGroups(msg, sender) {
                                       chrome.tabGroups.update(tgid, {'title' : groupName});
                                       openTabsInTg(tab.windowId, tgid, rest);
                                   });
-            });
+            }));
     });
 }
 


### PR DESCRIPTION
## Problem

Reported in #38 (Vivaldi 7.4): when the Topic Manager is run in WINDOW
(standalone panel) mode, clicking any link in the tree opens the
document **inside** the BT panel window, replacing the BT UI — rather
than in the user's main browser window. Only Vivaldi is affected;
Chrome, Edge behave correctly.

## Root cause

`background.js`'s `openTabs` / `openTabGroups` call `chrome.tabs.create({url})`
without a `windowId` whenever the parent topic has no siblings already open.
Chrome's `currentWindow` resolution explicitly skips `popup` / `panel` /
`devtools` window types, so on standard Chromium the new tab lands in
the user's most-recently-focused **normal** window — exactly what we want.

Vivaldi's `currentWindow` resolution does not exclude its own panel
windows, so the new tab is routed into the BT panel itself.

## Fix

A small helper `nonBTWindowId()` returns the id of a non-BT normal
window to pass to `chrome.tabs.create`. It is a **Vivaldi-only
workaround** — it returns `null` on every other browser, so their code
paths are byte-identical to before this PR.

Vivaldi detection uses the `vivExtData` property that Vivaldi attaches
to every `Window` object (verified absent on Chrome/Edge). This is
robust to Vivaldi's UA-masking setting, which by default makes Vivaldi
indistinguishable from Chrome via `navigator.userAgent` /
`userAgentData`.

The helper is also used in `openTabGroups` so "Open All" / tab-group
restores get the same treatment.

## Testing

- **Vivaldi 7.9.3970.64 (Windows 11)**: WINDOW mode — single-link click and
  "Open All" both open in the user's main browser window; BT panel
  untouched. Sibling-grouping still routes to the sibling's window.
- **Chrome stable**: WINDOW / TAB / SIDEPANEL modes — behavior
  unchanged from before this PR (helper returns `null`, same code path
  as today).
- TAB mode and SIDEPANEL mode also unchanged on Vivaldi (helper early-returns
  before the Vivaldi probe).